### PR TITLE
Added base-tag to content_html-attribute

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -1,7 +1,7 @@
 ---
 layout: null
 ---
-{
+{% capture base_tag %}<base href="{{ site.baseurl | prepend: site.url }}">{% endcapture %}{
     "version": "https://jsonfeed.org/version/1",
     "title": "{{ site.title | xml_escape }}",
     "home_page_url": "{{ "/" | absolute_url }}",
@@ -17,7 +17,7 @@ layout: null
             "title": {{ post.title | jsonify }},
             "summary": {{ post.seo_description | jsonify }},
             "content_text": {{ post.content | strip_html | strip_newlines | jsonify }},
-            "content_html": {{ post.content | strip_newlines | jsonify }},
+            "content_html": {{ post.content | prepend: base_tag | strip_newlines | jsonify }},
             "url": "{{ post.url | absolute_url }}",
             {% if post.image.size > 1 %}"image": "{{ post.image }}",{% endif %}
             {% if post.link.size > 1 %}"external_url": "{{ post.link }}",{% endif %}


### PR DESCRIPTION
I was so blunt to directly create a pull request. If you don't like it, no problem! It's just a small change.

I've added a base-tag to the content-html-attribute, because content may contain relative URLs. When using a feed on sites like http://json-feed-viewer.herokuapp.com/, the URL's will resolve.

I haven't tested this exact change, but it's copied from my own template (which I made, before I discoved this one). 