### PR TITLE
Added missing endif to tags attribute

### DIFF
--- a/feed.json
+++ b/feed.json
@@ -22,7 +22,7 @@ layout: null
             {% if post.image.size > 1 %}"image": "{{ post.image }}",{% endif %}
             {% if post.link.size > 1 %}"external_url": "{{ post.link }}",{% endif %}
             {% if post.banner.size > 1 %}"banner_image": "{{ post.banner }}",{% endif %}
-            {% if post.tags.size > 1 %}"tags": {{ post.tags | jsonify }},
+            {% if post.tags.size > 1 %}"tags": {{ post.tags | jsonify }},{% endif %}
             {% if post.enclosure.size > 1 %}"attachments": [
             {
               "url": "{{ post.enclosure }}",


### PR DESCRIPTION
Was getting a confusing `unknown tag 'endfor'` error, turns out there was just an `endif` missing.